### PR TITLE
Fixed wrong tags filtering parameter

### DIFF
--- a/src/components/blueprint-dialog/subcomponents/tags.tsx
+++ b/src/components/blueprint-dialog/subcomponents/tags.tsx
@@ -6,7 +6,7 @@ export const Tags = ({ tags }: { tags: IBlueprintDetails['tags'] }) => {
   return (
     <div className="flex flex-wrap gap-2">
       {tags?.map((tag: any) => (
-        <Link to={`/search?tags=${tag!.id}`} key={tag.id}>
+        <Link to={`/search?it=${tag!.id}`} key={tag.id}>
           <Tag>{tag.name}</Tag>
         </Link>
       ))}


### PR DESCRIPTION
Tag elements on main page behave correctly, while in card itself it has different url parameter which leads to non-working filtering